### PR TITLE
Functional essentials

### DIFF
--- a/src/lisp/context/base.rs
+++ b/src/lisp/context/base.rs
@@ -96,9 +96,10 @@ impl Context {
         ret.define("zero?", (|e| Ok((e == 0.into()).into())).into());
         ret.define("add1", make_unary_numeric(|e| e + 1.));
         ret.define("sub1", make_unary_numeric(|e| e - 1.));
-        ret.define("=", make_binary_numeric(|l, r| {
-            (l - r).abs() < std::f64::EPSILON
-        }));
+        ret.define(
+            "=",
+            make_binary_numeric(|l, r| (l - r).abs() < std::f64::EPSILON),
+        );
         ret.define("<", make_binary_numeric(|l, r| l < r));
         ret.define(">", make_binary_numeric(|l, r| l > r));
         ret.define("abs", make_unary_numeric(f64::abs));

--- a/src/lisp/sexp/eval/helpers.rs
+++ b/src/lisp/sexp/eval/helpers.rs
@@ -197,9 +197,12 @@ impl SExp {
                                     head: val,
                                     tail: box Null,
                                 },
-                        } => match val.eval(ctx) {
-                            Ok(result) => ctx.define(&key, result),
-                            err => return err,
+                        } => match *val {
+                            Null => ctx.define(&key, Null),
+                            _ => match val.eval(ctx) {
+                                Ok(result) => ctx.define(&key, result),
+                                err => return err,
+                            },
                         },
                         exp => {
                             return Err(LispError::SyntaxError {
@@ -287,6 +290,29 @@ impl SExp {
                 .into_iter()
                 .map(|e| Null.cons(e).cons((*head).to_owned()).eval(ctx))
                 .collect(),
+            exp => Err(LispError::SyntaxError {
+                exp: exp.to_string(),
+            }),
+        }
+    }
+
+    pub(super) fn eval_fold(self, ctx: &mut Context) -> LispResult {
+        match self {
+            Pair {
+                head,
+                tail:
+                    box Pair {
+                        head: init,
+                        tail:
+                            box Pair {
+                                head: expr,
+                                tail: box Null,
+                            },
+                    },
+            } => expr.eval(ctx)?.into_iter().fold(Ok(*init), |a, e| match a {
+                Ok(acc) => Null.cons(e).cons(acc).cons((*head).to_owned()).eval(ctx),
+                err => err,
+            }),
             exp => Err(LispError::SyntaxError {
                 exp: exp.to_string(),
             }),

--- a/src/lisp/sexp/eval/helpers.rs
+++ b/src/lisp/sexp/eval/helpers.rs
@@ -272,4 +272,40 @@ impl SExp {
             }),
         }
     }
+
+    pub(super) fn eval_map(self, ctx: &mut Context) -> LispResult {
+        match self {
+            Pair {
+                head,
+                tail:
+                    box Pair {
+                        head: expr,
+                        tail: box Null,
+                    },
+            } => expr
+                .eval(ctx)?
+                .into_iter()
+                .map(|e| Null.cons(e).cons((*head).to_owned()).eval(ctx))
+                .collect(),
+            exp => Err(LispError::SyntaxError {
+                exp: exp.to_string(),
+            }),
+        }
+    }
+
+    pub(super) fn do_apply(self, ctx: &mut Context) -> LispResult {
+        match self {
+            Pair {
+                head: op,
+                tail:
+                    box Pair {
+                        head: args,
+                        tail: box Null,
+                    },
+            } => args.eval(ctx)?.cons(*op).eval(ctx),
+            exp => Err(LispError::SyntaxError {
+                exp: exp.to_string(),
+            }),
+        }
+    }
 }

--- a/src/lisp/sexp/eval/mod.rs
+++ b/src/lisp/sexp/eval/mod.rs
@@ -46,6 +46,8 @@ impl SExp {
             Pair { head, tail } => {
                 if let Atom(Primitive::Symbol(sym)) = *head {
                     match sym.as_ref() {
+                        "eval" => (&tail).car().unwrap_or(*tail).eval(ctx)?.eval(ctx),
+                        "apply" => tail.do_apply(ctx),
                         "and" => tail.eval_and(ctx),
                         "begin" => tail.eval_begin(ctx),
                         "cond" => tail.eval_cond(ctx),
@@ -56,6 +58,7 @@ impl SExp {
                         "or" => tail.eval_or(ctx),
                         "quote" => Ok(tail.eval_quote()),
                         "set!" => tail.eval_set(ctx),
+                        "map" => tail.eval_map(ctx),
                         _ => tail.cons(SExp::make_symbol(&sym)).eval_typical_pair(ctx),
                     }
                 } else {

--- a/src/lisp/sexp/eval/mod.rs
+++ b/src/lisp/sexp/eval/mod.rs
@@ -63,6 +63,7 @@ impl SExp {
                         "set!" => tail.eval_set(ctx),
                         "map" => tail.eval_map(ctx),
                         "foldl" => tail.eval_fold(ctx),
+                        "filter" => tail.eval_filter(ctx),
                         _ => tail.cons(SExp::make_symbol(&sym)).eval_typical_pair(ctx),
                     }
                 } else {

--- a/src/lisp/sexp/eval/mod.rs
+++ b/src/lisp/sexp/eval/mod.rs
@@ -34,7 +34,10 @@ impl SExp {
             Null => Err(LispError::NullList),
             Atom(Primitive::Symbol(sym)) => match ctx.get(&sym) {
                 None => Err(LispError::UndefinedSymbol { sym }),
-                Some(exp) => exp.eval(ctx),
+                Some(exp) => match exp {
+                    Null => Ok(Null),
+                    _ => exp.eval(ctx),
+                },
             },
             Atom(_) => Ok(self),
             Pair { .. } => self.eval_pair(ctx),
@@ -59,6 +62,7 @@ impl SExp {
                         "quote" => Ok(tail.eval_quote()),
                         "set!" => tail.eval_set(ctx),
                         "map" => tail.eval_map(ctx),
+                        "foldl" => tail.eval_fold(ctx),
                         _ => tail.cons(SExp::make_symbol(&sym)).eval_typical_pair(ctx),
                     }
                 } else {


### PR DESCRIPTION
implements these goodies (closing #13), and makes some fixes to accomodate them:
- map
- filter
- foldl
- eval
- apply

filter could have been a regular function if lexical closures were working (see #1):
```scheme
(define (filter pred lst)
 (foldl 
  (lambda (acc elem)
   (if (pred elem) (cons acc elem) acc))
  null
  lst))
```

however, implementing it natively might be more performant. not sure as we cannot A/B test.